### PR TITLE
Fixed UserController retrieving wrong parameter

### DIFF
--- a/src/CmsBundle/Controller/Backend/UserController.php
+++ b/src/CmsBundle/Controller/Backend/UserController.php
@@ -17,7 +17,7 @@ class UserController extends Controller
      */
     public function indexAction()
     {
-        $source = new Entity($this->container->getParameter('opifer_cms.user.class'));
+        $source = new Entity($this->container->getParameter('opifer_cms.user.model'));
 
         $editAction = new RowAction('edit', 'opifer_cms_user_edit');
         $editAction->setRouteParameters(['id']);
@@ -43,7 +43,7 @@ class UserController extends Controller
      */
     public function newAction(Request $request)
     {
-        $user = $this->container->getParameter('opifer_cms.user.class');
+        $user = $this->container->getParameter('opifer_cms.user.model');
         $user = new $user();
 
         $form = $this->createForm($this->get('opifer.cms.user_form'), $user);

--- a/src/CmsBundle/DependencyInjection/OpiferCmsExtension.php
+++ b/src/CmsBundle/DependencyInjection/OpiferCmsExtension.php
@@ -73,14 +73,7 @@ class OpiferCmsExtension extends Extension implements PrependExtensionInterface
     {
         foreach ($classes as $model => $serviceClasses) {
             foreach ($serviceClasses as $service => $class) {
-                $container->setParameter(
-                    sprintf(
-                        'opifer_cms.%s_%s',
-                        $model,
-                        $service
-                    ),
-                    $class
-                );
+                $container->setParameter(sprintf('opifer_cms.%s.%s', $model, $service), $class);
             }
         }
     }

--- a/src/CmsBundle/Resources/config/config.yml
+++ b/src/CmsBundle/Resources/config/config.yml
@@ -98,7 +98,7 @@ doctrine:
                 class:   'Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter'
                 enabled: true
         resolve_target_entities:
-            FOS\UserBundle\Model\UserInterface: '%opifer_cms.user_model%'
+            FOS\UserBundle\Model\UserInterface: '%opifer_cms.user.model%'
             Opifer\EavBundle\Nesting\Nestable: 'Opifer\CmsBundle\Entity\Content'
         mappings:
             translatable:
@@ -128,7 +128,7 @@ doctrine_migrations:
 fos_user:
     db_driver:       'orm'
     firewall_name:   'main'
-    user_class:      '%opifer_cms.user_model%'
+    user_class:      '%opifer_cms.user.model%'
     group:
         group_class: 'Opifer\CmsBundle\Entity\Group'
     registration:

--- a/src/CmsBundle/Resources/config/services.yml
+++ b/src/CmsBundle/Resources/config/services.yml
@@ -49,7 +49,7 @@ services:
 
     opifer.cms.user_form:
         class: '%opifer.cms.user_form.class%'
-        arguments: ['%security.role_hierarchy.roles%', '%opifer_cms.user_model%']
+        arguments: ['%security.role_hierarchy.roles%', '%opifer_cms.user.model%']
         tags:
             - { name: 'form.type', alias: 'admin_user_form' }
 


### PR DESCRIPTION
Changed the separator for dynamic model classes from `_` to `.`, so model and e.g. repository are grouped more logically:

`opifer_cms.user.model`
`opifer_cms.user.repository`

instead of

`opifer_cms.user_model`
`opifer_cms.user_repository`
