### PR TITLE
Get short title in breadcrumbs block

### DIFF
--- a/src/ContentBundle/Model/Content.php
+++ b/src/ContentBundle/Model/Content.php
@@ -882,7 +882,7 @@ class Content implements ContentInterface, EntityInterface, TemplatedInterface, 
             $crumbs = $this->getParent()->getBreadCrumbs();
         }
 
-        $crumbs[$this->slug] = $this->getTitle();
+        $crumbs[$this->slug] = $this->getShortTitle();
 
         return $crumbs;
     }


### PR DESCRIPTION
Changed getTitle() into getShortTitle() in getBreadCrumbs(), to keep a clean breadcrumb bar.
