### PR TITLE
Cache cover images for content

### DIFF
--- a/src/CmsBundle/Resources/config/config.yml
+++ b/src/CmsBundle/Resources/config/config.yml
@@ -216,6 +216,7 @@ apy_data_grid:
 # Content
 opifer_content:
     content_manager: 'opifer.cms.content_manager'
+    cache_provider: 'Doctrine\Common\Cache\ApcuCache'
     content:
         class: Opifer\CmsBundle\Entity\Content
         views:

--- a/src/ContentBundle/DependencyInjection/Configuration.php
+++ b/src/ContentBundle/DependencyInjection/Configuration.php
@@ -73,7 +73,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
-
+                ->scalarNode('cache_provider')->defaultValue('Doctrine\Common\Cache\ArrayCache')->end()
             ->end()
         ;
 

--- a/src/ContentBundle/DependencyInjection/OpiferContentExtension.php
+++ b/src/ContentBundle/DependencyInjection/OpiferContentExtension.php
@@ -4,19 +4,20 @@ namespace Opifer\ContentBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * This is the class that loads and manages your bundle configuration
+ * This is the class that loads and manages your bundle configuration.
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
 class OpiferContentExtension extends Extension implements PrependExtensionInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -26,9 +27,32 @@ class OpiferContentExtension extends Extension implements PrependExtensionInterf
     }
 
     /**
-     * Simplifying parameter syntax
+     * Prepend our config before other bundles, so we can preset
+     * their config with our parameters.
      *
-     * @param  array $config
+     * @param ContainerBuilder $container
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        $configs = $container->getExtensionConfig($this->getAlias());
+        $config = $this->processConfiguration(new Configuration(), $configs);
+
+        $container->setAlias('opifer.content.content_manager', $config['content_manager']);
+        $container->setDefinition('opifer.content.cache_provider', new Definition($config['cache_provider']));
+
+        $parameters = $this->getParameters($config);
+        foreach ($parameters as $key => $value) {
+            $container->setParameter($key, $value);
+        }
+
+        $this->prependExtensionConfig($container, $config);
+    }
+
+    /**
+     * Simplifying parameter syntax.
+     *
+     * @param array $config
+     *
      * @return array
      */
     public function getParameters(array $config)
@@ -58,25 +82,11 @@ class OpiferContentExtension extends Extension implements PrependExtensionInterf
     }
 
     /**
-     * Prepend our config before other bundles, so we can preset
-     * their config with our parameters
-     *
-     * @param  ContainerBuilder $container
-     *
-     * @return void
+     * @param ContainerBuilder $container
+     * @param array            $config
      */
-    public function prepend(ContainerBuilder $container)
+    private function prependExtensionConfig(ContainerBuilder $container, array $config)
     {
-        $configs = $container->getExtensionConfig($this->getAlias());
-        $config = $this->processConfiguration(new Configuration(), $configs);
-
-        $container->setAlias('opifer.content.content_manager', $config['content_manager']);
-
-        $parameters = $this->getParameters($config);
-        foreach ($parameters as $key => $value) {
-            $container->setParameter($key, $value);
-        }
-
         foreach ($container->getExtensions() as $name => $extension) {
             switch ($name) {
                 case 'doctrine':

--- a/src/ContentBundle/Resources/config/services.yml
+++ b/src/ContentBundle/Resources/config/services.yml
@@ -46,7 +46,7 @@ services:
 
     opifer.content.content_serializer_subscriber:
         class: Opifer\ContentBundle\EventListener\Serializer\ContentEventSubscriber
-        arguments: ['@liip_imagine.cache.manager', '@router']
+        arguments: ['@liip_imagine.cache.manager', '@router', '@opifer.content.cache_provider']
         tags:
             - { name: jms_serializer.event_subscriber }
 

--- a/src/ContentBundle/Resources/config/services.yml
+++ b/src/ContentBundle/Resources/config/services.yml
@@ -44,7 +44,7 @@ services:
 
     # Serializer
 
-    opifer.content.handler.serialization:
+    opifer.content.content_serializer_subscriber:
         class: Opifer\ContentBundle\EventListener\Serializer\ContentEventSubscriber
         arguments: ['@liip_imagine.cache.manager', '@router']
         tags:


### PR DESCRIPTION
This is a first step into caching data manually. We need a proper way to define a custom cache provider instead of forcing the usage of `Apcu` (in this case), which could be accessible from any of our bundles.
