### PR TITLE
Renamed card to cards

### DIFF
--- a/src/ContentBundle/Block/Service/ListBlockService.php
+++ b/src/ContentBundle/Block/Service/ListBlockService.php
@@ -84,7 +84,7 @@ class ListBlockService extends AbstractBlockService implements BlockServiceInter
                 'label' => 'label.list_display_type',
                 'choices'  => [
                     'list' => 'List',
-                    'card' => 'Cards',
+                    'cards' => 'Cards',
                     'table' => 'Table',
                 ],
                 'required' => true,


### PR DESCRIPTION
Renamed it to cards because it is the parent class of card. It determines the widths of the columns set.