### PR TITLE
Added background image ratio

### DIFF
--- a/src/ContentBundle/Block/Service/CardBlockService.php
+++ b/src/ContentBundle/Block/Service/CardBlockService.php
@@ -70,6 +70,7 @@ class CardBlockService extends AbstractBlockService implements BlockServiceInter
                     '23' => '2:3 (portrait)',
                     '169'=> '16:9',
                     '916'=> '9:16 (portrait)',
+                    'bg' => 'Background cover',
                 ],
                 'required' => true,
                 'expanded' => false,


### PR DESCRIPTION
When using flex box, the image needs to be scaled with all its flex items. By adding a "bg" property we will be able to use it like that.