### PR TITLE
Avoid limiting findDescendants to CompositeBlocks

### DIFF
--- a/src/ContentBundle/Block/BlockManager.php
+++ b/src/ContentBundle/Block/BlockManager.php
@@ -204,17 +204,23 @@ class BlockManager
         return $blocks;
     }
 
-    public function findDescendants(CompositeBlock $parent, $draft = true)
+    /**
+     * Finds the block and all its children recursively
+     *
+     * @param BlockInterface $parent
+     * @param bool $draft
+     * @return BlockInterface[]
+     */
+    public function findDescendants($parent, $draft = true)
     {
         $this->setDraftVersionFilter(! $draft);
-
-        $blocks = [];
-
+        
         $iterator = new \RecursiveIteratorIterator(
             new RecursiveBlockIterator([$parent]),
             \RecursiveIteratorIterator::SELF_FIRST
         );
 
+        $blocks = [];
         foreach ($iterator as $descendant) {
             $blocks[] = $descendant;
         }

--- a/src/ContentBundle/Model/BlockInterface.php
+++ b/src/ContentBundle/Model/BlockInterface.php
@@ -2,6 +2,8 @@
 
 namespace Opifer\ContentBundle\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
+
 interface BlockInterface
 {
     public function getId();
@@ -57,4 +59,9 @@ interface BlockInterface
      * @return \DateTime
      */
     public function getUpdatedAt();
+
+    /**
+     * @return ArrayCollection|BlockInterface[]
+     */
+    public function getChildren();
 }


### PR DESCRIPTION
This fixes an issue when publishing a page in which a non-CompositeBlock root block (e.g. HTMLBlock) is removed.