### PR TITLE
Reduce media serialization to medialibrary filter only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+This changelog references all relevant changes. Latest changes at the top.
+
+- [MediaBundle] #305 Removed serializing and caching image urls of all image sizes

--- a/src/MediaBundle/EventListener/Serializer/MediaEventSubscriber.php
+++ b/src/MediaBundle/EventListener/Serializer/MediaEventSubscriber.php
@@ -77,11 +77,11 @@ class MediaEventSubscriber implements EventSubscriberInterface
         $provider = $this->getProvider($media);
 
         if ($provider->getName() == 'image') {
-            $images = $this->getImages($media);
+            $images = $this->getImages($media, ['medialibrary']);
 
             $event->getVisitor()->addData('images', $images);
 
-            $event->getVisitor()->addData('original', $images['full_size']);
+            $event->getVisitor()->addData('original', $provider->getUrl($media));
         } else {
             $event->getVisitor()->addData('original', $provider->getUrl($media));
         }
@@ -91,18 +91,17 @@ class MediaEventSubscriber implements EventSubscriberInterface
      * Gets the cached images if any. If the cache is not present, it generates images for all filters.
      *
      * @param MediaInterface $media
+     * @param array $filters
      *
      * @return MediaInterface[]
      */
-    public function getImages(MediaInterface $media)
+    public function getImages(MediaInterface $media, array $filters)
     {
         $key = $media->getImagesCacheKey();
         if (!$images = $this->cache->fetch($key)) {
             $provider = $this->getProvider($media);
 
             $reference = $provider->getThumb($media);
-
-            $filters = array_keys($this->filterConfig->all());
 
             $images = [];
             foreach ($filters as $filter) {

--- a/src/MediaBundle/EventListener/Serializer/MediaEventSubscriber.php
+++ b/src/MediaBundle/EventListener/Serializer/MediaEventSubscriber.php
@@ -80,11 +80,9 @@ class MediaEventSubscriber implements EventSubscriberInterface
             $images = $this->getImages($media, ['medialibrary']);
 
             $event->getVisitor()->addData('images', $images);
-
-            $event->getVisitor()->addData('original', $provider->getUrl($media));
-        } else {
-            $event->getVisitor()->addData('original', $provider->getUrl($media));
         }
+
+        $event->getVisitor()->addData('original', $provider->getUrl($media));
     }
 
     /**


### PR DESCRIPTION
I limited the image serialization to `medialibrary` filters only, since as far as I could see, that's the only filter used in the backend after serialization.