### PR TITLE
Added fix in dimensions for allowed_filters

### DIFF
--- a/src/ContentBundle/Block/Service/ImageBlockService.php
+++ b/src/ContentBundle/Block/Service/ImageBlockService.php
@@ -112,7 +112,7 @@ class ImageBlockService extends AbstractBlockService implements BlockServiceInte
             foreach ($set['filters'] as $filter => $properties) {
                 switch ($filter) {
                     case 'thumbnail':
-                        $explanation[] = $properties['size'][0].' X '. $properties['size'][0];
+                        $explanation[] = $properties['size'][0].' X '. $properties['size'][1];
                         break;
                     case 'relative_resize':
                         $heighten = (isset($properties['heighten'])) ? $properties['heighten'] : '~';


### PR DESCRIPTION
The dimensions showed the following:

![image](https://cloud.githubusercontent.com/assets/8750142/26253605/40192570-3cb4-11e7-9327-55e60d3ce2f3.png)

Fixed the dimensions to width x height. Clients started asking about it.

![image](https://cloud.githubusercontent.com/assets/8750142/26253662/6f164ef2-3cb4-11e7-9382-f928c0968e7c.png)
