### PR TITLE
Remove HHVM builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
 
 cache:
   directories:
@@ -16,13 +15,11 @@ env:
   - SYMFONY_DEPRECATIONS_HELPER=weak
 
 matrix:
-  allow_failures:
-    - php: hhvm
   fast_finish: true
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
-  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
+  - phpenv config-rm xdebug.ini;
+  - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini;
   - composer self-update
 
 install:


### PR DESCRIPTION
Since [Symfony announced the end of HHVM support](http://symfony.com/blog/symfony-4-end-of-hhvm-support), I'd like to remove the Travis builds for HHVM to reduce build times.