### PR TITLE
Fixed adding new sites

### DIFF
--- a/src/CmsBundle/Controller/Backend/SiteController.php
+++ b/src/CmsBundle/Controller/Backend/SiteController.php
@@ -50,21 +50,17 @@ class SiteController extends Controller
 
         $site = new Site();
 
-        $originalDomains = new ArrayCollection();
-        foreach ($site->getDomains() as $domain) {
-            $originalDomains->add($domain);
-        }
-
         $form = $this->createForm(SiteType::class, $site);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
             $em = $this->getDoctrine()->getManager();
-            // Add new domain
+
             foreach ($form->getData()->getDomains() as $domain) {
                 $domain->setSite($site);
+
+                $em->persist($domain);
             }
-            $em->persist($domain);
 
             $em->persist($site);
             $em->flush();

--- a/src/CmsBundle/Entity/Site.php
+++ b/src/CmsBundle/Entity/Site.php
@@ -60,7 +60,6 @@ class Site
     /**
      * @var string
      *
-     * @Assert\NotBlank()
      * @JMS\Expose
      */
     private $defaultDomain;
@@ -257,9 +256,11 @@ class Site
         if ($this->defaultDomain) {
             return $this->defaultDomain;
         } elseif ($first = $this->getDomains()->first()) {
-            return $first->getDomain();
-        } else {
-            return null;
+            if ($first instanceof Domain) {
+                return $first->getDomain();
+            }
         }
+
+        return null;
     }
 }

--- a/src/CmsBundle/Form/Type/SiteType.php
+++ b/src/CmsBundle/Form/Type/SiteType.php
@@ -20,7 +20,7 @@ class SiteType extends AbstractType
             ->add('name')
             ->add('description')
             ->add('domains', BootstrapCollectionType::class, [
-                'type' => SiteDomainType::class,
+                'entry_type' => SiteDomainType::class,
                 'allow_add' => true,
                 'allow_delete' => true,
             ])

--- a/src/ContentBundle/Block/Service/CollectionBlockService.php
+++ b/src/ContentBundle/Block/Service/CollectionBlockService.php
@@ -133,7 +133,7 @@ class CollectionBlockService extends AbstractBlockService implements BlockServic
                 ->add('filters', BootstrapCollectionType::class, [
                     'allow_add' => true,
                     'allow_delete' => true,
-                    'type' => FilterType::class,
+                    'entry_type' => FilterType::class,
                     'attr' => [
                         'help_text' => 'Filters the user can use to search the collection',
                         'tag' => 'general'

--- a/src/ContentBundle/Controller/Frontend/ContentController.php
+++ b/src/ContentBundle/Controller/Frontend/ContentController.php
@@ -45,12 +45,12 @@ class ContentController extends Controller
 
         $domain = $em->getRepository(Domain::class)->findOneByDomain($request->getHost());
 
-        if ($siteCount && $domain->getSite()->getDefaultLocale()) {
-            $request->setLocale($domain->getSite()->getDefaultLocale()->getLocale());
-        }
-
         if (!$domain && $siteCount > 1) {
             return $this->render('OpiferContentBundle:Content:domain_not_found.html.twig');
+        }
+
+        if ($siteCount && $domain && $domain->getSite()->getDefaultLocale()) {
+            $request->setLocale($domain->getSite()->getDefaultLocale()->getLocale());
         }
 
         if ($content->getLocale()) {
@@ -112,12 +112,12 @@ class ContentController extends Controller
 
         $domain = $em->getRepository(Domain::class)->findOneByDomain($host);
 
-        if ($siteCount && $domain->getSite()->getDefaultLocale()) {
-            $request->setLocale($domain->getSite()->getDefaultLocale()->getLocale());
-        }
-
         if (!$domain && $siteCount > 1) {
             return $this->render('OpiferContentBundle:Content:domain_not_found.html.twig');
+        }
+
+        if ($siteCount && $domain && $domain->getSite()->getDefaultLocale()) {
+            $request->setLocale($domain->getSite()->getDefaultLocale()->getLocale());
         }
 
         $content = $manager->getRepository()->findActiveBySlug('index', $host);

--- a/src/FormBlockBundle/Block/Service/ChoiceFieldBlockService.php
+++ b/src/FormBlockBundle/Block/Service/ChoiceFieldBlockService.php
@@ -37,7 +37,7 @@ class ChoiceFieldBlockService extends FormFieldBlockService implements BlockServ
             ->add('options', BootstrapCollectionType::class, [
                 'allow_add' => true,
                 'allow_delete' => true,
-                'type' => KeyValueType::class,
+                'entry_type' => KeyValueType::class,
             ])
         ;
     }

--- a/src/FormBlockBundle/Block/Service/FormFieldBlockService.php
+++ b/src/FormBlockBundle/Block/Service/FormFieldBlockService.php
@@ -65,7 +65,7 @@ abstract class FormFieldBlockService extends AbstractBlockService implements Blo
                 'required' => false,
                 'allow_add' => true,
                 'allow_delete' => true,
-                'type' => FormFieldValidationType::class,
+                'entry_type' => FormFieldValidationType::class,
             ])
             ->add('formula', TextAreaType::class, [
                 'required' => false,


### PR DESCRIPTION
This PR fixes the ability to create new Site entities. It's currently not possible due to two reasons:

- It does not recognize the added domain as an object
- It expects the `defaultDomain` property to be passed, while this is an optional field.