### PR TITLE
Replaced property with choice_label

### DIFF
--- a/src/FormBundle/Form/Type/FormType.php
+++ b/src/FormBundle/Form/Type/FormType.php
@@ -83,7 +83,7 @@ class FormType extends AbstractType
             ->add('uploadDirectory', EntityType::class, [
                 'label' => 'Upload directory',
                 'class'    => MediaDirectory::class,
-                'property' => 'name',
+                'choice_label' => 'name',
                 'attr'     => [
                     'help_text'   => 'In case this form supports uploads, we can place the upload in a specified directory. If empty, the file will be placed in the root of the media manager',
                 ],


### PR DESCRIPTION
The option "property" has been removed in Symfony 3.