### PR TITLE
Use local phpunit dependency to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ before_install:
 install:
   - composer install --prefer-dist --no-interaction --no-scripts
 
-script: phpunit --coverage-text
+script: vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "symfony/symfony": "^3.0",
         "doctrine/orm": "~2.5.4",
         "doctrine/doctrine-bundle": "^1.6",
-        "beberlei/DoctrineExtensions": "^1.0",
+        "beberlei/doctrineextensions": "^1.0",
         "twig/extensions": "~1.2",
         "twig/twig": "~2.4",
         "symfony/swiftmailer-bundle": "~2.3",


### PR DESCRIPTION
All unit tests are currently failing since Travis' default global phpunit dependency does not support php7.1 anymore.