### PR TITLE
Always convert style preferences to a simple array

### DIFF
--- a/src/ContentBundle/Block/Service/AlertBlockService.php
+++ b/src/ContentBundle/Block/Service/AlertBlockService.php
@@ -5,6 +5,7 @@ namespace Opifer\ContentBundle\Block\Service;
 use Opifer\ContentBundle\Entity\AlertBlock;
 use Opifer\ContentBundle\Block\Tool\Tool;
 use Opifer\ContentBundle\Block\Tool\ToolsetMemberInterface;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Opifer\ContentBundle\Model\BlockInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -52,13 +53,8 @@ class AlertBlockService extends AbstractBlockService implements BlockServiceInte
 
 
         $builder->get('properties')
-            ->add('styles', ChoiceType::class, [
-                'label' => 'label.styling',
+            ->add('styles', StylesType::class, [
                 'choices'  => $this->config['styles'],
-                'required' => false,
-                'expanded' => true,
-                'multiple' => true,
-                'attr' => ['help_text' => 'help.html_styles', 'tag' => 'styles'],
             ]);
     }
 

--- a/src/ContentBundle/Block/Service/ButtonBlockService.php
+++ b/src/ContentBundle/Block/Service/ButtonBlockService.php
@@ -5,6 +5,7 @@ namespace Opifer\ContentBundle\Block\Service;
 use Opifer\ContentBundle\Block\Tool\Tool;
 use Opifer\ContentBundle\Block\Tool\ToolsetMemberInterface;
 use Opifer\ContentBundle\Entity\ButtonBlock;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Opifer\ContentBundle\Model\BlockInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -40,13 +41,8 @@ class ButtonBlockService extends AbstractBlockService implements BlockServiceInt
 
         if ($this->config['styles']) {
             $builder->get('properties')
-                ->add('styles', ChoiceType::class, [
-                    'label' => 'label.styling',
+                ->add('styles', StylesType::class, [
                     'choices'  => $this->config['styles'],
-                    'required' => false,
-                    'expanded' => true,
-                    'multiple' => true,
-                    'attr'     => ['tag' => 'styles'],
                 ]);
         }
 

--- a/src/ContentBundle/Block/Service/CardBlockService.php
+++ b/src/ContentBundle/Block/Service/CardBlockService.php
@@ -7,6 +7,7 @@ use Opifer\ContentBundle\Block\Tool\Tool;
 use Opifer\ContentBundle\Block\Tool\ToolsetMemberInterface;
 use Opifer\ContentBundle\Entity\CardBlock;
 use Opifer\ContentBundle\Form\Type\ContentPickerType;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Opifer\MediaBundle\Form\Type\MediaPickerType;
@@ -53,12 +54,8 @@ class CardBlockService extends AbstractBlockService implements BlockServiceInter
                 'choices'     => $this->config['presets'],
                 'required'    => true,
             ])
-            ->add('styles', ChoiceType::class, [
-                'label' => 'label.styling',
+            ->add('styles', StylesType::class, [
                 'choices'  => $this->config['styles'],
-                'required' => false,
-                'expanded' => true,
-                'multiple' => true,
                 'attr' => [
                     'help_text' => 'help.html_styles',
                     'class' => 'radio-rows',

--- a/src/ContentBundle/Block/Service/CarouselSlideBlockService.php
+++ b/src/ContentBundle/Block/Service/CarouselSlideBlockService.php
@@ -6,6 +6,7 @@ use Opifer\CmsBundle\Form\Type\CKEditorType;
 use Opifer\ContentBundle\Block\Tool\Tool;
 use Opifer\ContentBundle\Block\Tool\ToolsetMemberInterface;
 use Opifer\ContentBundle\Entity\CarouselSlideBlock;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Opifer\ContentBundle\Model\BlockInterface;
 use Opifer\MediaBundle\Form\Type\MediaPickerType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -32,16 +33,8 @@ class CarouselSlideBlockService extends AbstractBlockService implements BlockSer
 
         if ($this->config['styles']) {
             $builder->get('properties')
-                ->add('styles', ChoiceType::class, [
-                    'label' => 'label.styling',
+                ->add('styles', StylesType::class, [
                     'choices'  => array_combine($this->config['styles'], $this->config['styles']),
-                    'required' => false,
-                    'expanded' => true,
-                    'multiple' => true,
-                    'attr' => [
-                        'help_text' => 'help.html_styles',
-                        'tag' => 'styles'
-                    ],
                 ]);
         }
 

--- a/src/ContentBundle/Block/Service/CollectionBlockService.php
+++ b/src/ContentBundle/Block/Service/CollectionBlockService.php
@@ -9,6 +9,7 @@ use Opifer\ContentBundle\Block\Tool\Tool;
 use Opifer\ContentBundle\Block\Tool\ToolsetMemberInterface;
 use Opifer\ContentBundle\Entity\CollectionBlock;
 use Opifer\ContentBundle\Form\Type\FilterType;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Opifer\ContentBundle\Model\BlockInterface;
 use Opifer\ContentBundle\Model\ContentManagerInterface;
 use Opifer\ContentBundle\Model\ContentTypeInterface;
@@ -172,14 +173,10 @@ class CollectionBlockService extends AbstractBlockService implements BlockServic
         }
 
         if ($this->config['styles']) {
-            $builder->get('properties')->add('styles', ChoiceType::class, [
-                'label' => 'label.styling',
-                'choices' => $this->config['styles'],
-                'required' => false,
-                'expanded' => true,
-                'multiple' => true,
-                'attr' => ['help_text' => 'help.html_styles', 'tag' => 'styles'],
-            ]);
+            $builder->get('properties')
+                ->add('styles', StylesType::class, [
+                    'choices' => $this->config['styles'],
+                ]);
         }
     }
 

--- a/src/ContentBundle/Block/Service/ColumnBlockService.php
+++ b/src/ContentBundle/Block/Service/ColumnBlockService.php
@@ -9,6 +9,7 @@ use Opifer\ContentBundle\Block\Tool\ToolsetMemberInterface;
 use Opifer\ContentBundle\Entity\ColumnBlock;
 use Opifer\ContentBundle\Form\Type\GutterCollectionType;
 use Opifer\ContentBundle\Form\Type\SpanCollectionType;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Opifer\ContentBundle\Model\BlockInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -116,19 +117,12 @@ class ColumnBlockService extends AbstractBlockService implements LayoutBlockServ
             }
 
             $form->get('properties')
-                ->add('styles', ChoiceType::class, [
-                    'label' => 'label.styling',
+                ->add('styles', StylesType::class, [
                     'choices' => $this->config['styles'],
-                    'required' => false,
-                    'expanded' => true,
-                    'multiple' => true,
                     'attr' => [
                         'help_text' => 'help.list_display_size',
-                        // 'class' => 'btn-group btn-group-styling', 
-                        // 'data-toggle' => 'buttons',
                         'tag' => 'styles'
                     ],
-                    // 'label_attr' => ['class' => 'btn'],
                 ])
                 ->add('spans', SpanCollectionType::class, [
                     'column_count' => $block->getColumnCount(),

--- a/src/ContentBundle/Block/Service/ContainerBlockService.php
+++ b/src/ContentBundle/Block/Service/ContainerBlockService.php
@@ -5,6 +5,7 @@ namespace Opifer\ContentBundle\Block\Service;
 use Opifer\ContentBundle\Block\Tool\Tool;
 use Opifer\ContentBundle\Block\Tool\ToolsetMemberInterface;
 use Opifer\ContentBundle\Entity\ContainerBlock;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Opifer\ContentBundle\Model\BlockInterface;
 use Opifer\ContentBundle\Form\Type\BoxModelType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -43,19 +44,12 @@ class ContainerBlockService extends AbstractBlockService implements LayoutBlockS
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
             $form = $event->getForm();
-        
+
             if (count($this->config['styles'])) {
-                $form->get('properties')->add('styles', ChoiceType::class, [
-                    'label' => 'label.styling',
-                    'choices'  => $this->config['styles'],
-                    'required' => false,
-                    'expanded' => true,
-                    'multiple' => true,
-                    'attr' => [
-                        'help_text' => 'help.html_styles',
-                        'tag' => 'styles'
-                    ],
-                ]);
+                $form->get('properties')
+                    ->add('styles', StylesType::class, [
+                        'choices'  => $this->config['styles'],
+                    ]);
             }
 
             $form->get('properties')

--- a/src/ContentBundle/Block/Service/IFrameBlockService.php
+++ b/src/ContentBundle/Block/Service/IFrameBlockService.php
@@ -5,6 +5,7 @@ namespace Opifer\ContentBundle\Block\Service;
 use Opifer\ContentBundle\Block\Tool\Tool;
 use Opifer\ContentBundle\Block\Tool\ToolsetMemberInterface;
 use Opifer\ContentBundle\Entity\IFrameBlock;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -50,13 +51,8 @@ class IFrameBlockService extends AbstractBlockService implements BlockServiceInt
 
         if ($this->config['styles']) {
             $builder->get('properties')
-                ->add('styles', ChoiceType::class, [
-                    'label' => 'label.styling',
+                ->add('styles', StylesType::class, [
                     'choices' => $this->config['styles'],
-                    'required' => false,
-                    'expanded' => true,
-                    'multiple' => true,
-                    'attr' => ['help_text' => 'help.html_styles', 'tag' => 'styles'],
                 ]);
         }
     }

--- a/src/ContentBundle/Block/Service/ImageBlockService.php
+++ b/src/ContentBundle/Block/Service/ImageBlockService.php
@@ -6,6 +6,7 @@ use Opifer\ContentBundle\Block\BlockRenderer;
 use Opifer\ContentBundle\Block\Tool\Tool;
 use Opifer\ContentBundle\Block\Tool\ToolsetMemberInterface;
 use Opifer\ContentBundle\Entity\ImageBlock;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Opifer\ContentBundle\Model\BlockInterface;
 use Opifer\MediaBundle\Form\Type\MediaPickerType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -74,13 +75,8 @@ class ImageBlockService extends AbstractBlockService implements BlockServiceInte
         );
 
         $builder->get('properties')
-            ->add('styles', ChoiceType::class, [
-                'label' => 'label.styling',
+            ->add('styles', StylesType::class, [
                 'choices'  => $this->config['styles'],
-                'required' => false,
-                'expanded' => true,
-                'multiple' => true,
-                'attr' => ['help_text' => 'help.html_styles','tag' => 'styles'],
             ]);
     }
 

--- a/src/ContentBundle/Block/Service/JumbotronBlockService.php
+++ b/src/ContentBundle/Block/Service/JumbotronBlockService.php
@@ -6,6 +6,7 @@ use Opifer\CmsBundle\Form\Type\CKEditorType;
 use Opifer\ContentBundle\Block\Tool\Tool;
 use Opifer\ContentBundle\Block\Tool\ToolsetMemberInterface;
 use Opifer\ContentBundle\Entity\JumbotronBlock;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Opifer\ContentBundle\Model\BlockInterface;
 use Opifer\MediaBundle\Form\Type\MediaPickerType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -53,13 +54,8 @@ class JumbotronBlockService extends AbstractBlockService implements BlockService
 
         if ($this->config['styles']) {
             $builder->get('properties')
-                ->add('styles', ChoiceType::class, [
-                    'label' => 'label.styling',
+                ->add('styles', StylesType::class, [
                     'choices'  => $this->config['styles'],
-                    'required' => false,
-                    'expanded' => true,
-                    'multiple' => true,
-                    'attr' => ['help_text' => 'help.html_styles','tag' => 'styles'],
                 ]);
         }
 

--- a/src/ContentBundle/Block/Service/ListBlockService.php
+++ b/src/ContentBundle/Block/Service/ListBlockService.php
@@ -8,6 +8,7 @@ use Opifer\ContentBundle\Block\Tool\Tool;
 use Opifer\ContentBundle\Block\Tool\ToolsetMemberInterface;
 use Opifer\ContentBundle\Entity\ListBlock;
 use Opifer\ContentBundle\Form\Type\ContentListPickerType;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Opifer\ContentBundle\Model\BlockInterface;
 use Opifer\ContentBundle\Model\ContentManagerInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -86,13 +87,8 @@ class ListBlockService extends AbstractBlockService implements BlockServiceInter
         }
 
         if ($this->config['styles']) {
-            $builder->get('properties')->add('styles', ChoiceType::class, [
-                'label' => 'label.styling',
+            $builder->get('properties')->add('styles', StylesType::class, [
                 'choices' => $this->config['styles'],
-                'required' => false,
-                'expanded' => true,
-                'multiple' => true,
-                'attr' => ['help_text' => 'help.html_styles', 'tag' => 'styles'],
             ]);
         }
     }

--- a/src/ContentBundle/Block/Service/ModalBlockService.php
+++ b/src/ContentBundle/Block/Service/ModalBlockService.php
@@ -5,6 +5,7 @@ namespace Opifer\ContentBundle\Block\Service;
 use Opifer\CmsBundle\Form\Type\CKEditorType;
 use Opifer\ContentBundle\Entity\Block;
 use Opifer\ContentBundle\Entity\ButtonBlock;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Opifer\FormBlockBundle\Entity\FormFieldBlock;
 use Opifer\FormBlockBundle\Entity\ChoiceFieldBlock;
 use Opifer\FormBlockBundle\Form\Type\FormFieldValidationType;
@@ -101,14 +102,9 @@ class ModalBlockService extends AbstractBlockService implements BlockServiceInte
 
         if (isset($this->config['styles']) && count($this->config['styles'])) {
             $builder->get('properties')
-                ->add('styles', ChoiceType::class, [
-                    'label' => 'label.styling',
+                ->add('styles', StylesType::class, [
                     'choices'  => $this->config['styles'],
-                    'required' => false,
-                    'expanded' => true,
-                    'multiple' => true,
-                    'attr' => ['help_text' => 'help.html_styles', 'tag' => 'styles'],
-            ]);
+                ]);
         }
 
         if (isset($this->config['template']) && count($this->config['template'])) {

--- a/src/ContentBundle/Block/Service/SectionBlockService.php
+++ b/src/ContentBundle/Block/Service/SectionBlockService.php
@@ -7,6 +7,7 @@ use Opifer\ContentBundle\Block\Tool\Tool;
 use Opifer\ContentBundle\Block\Tool\ToolsetMemberInterface;
 use Opifer\ContentBundle\Entity\SectionBlock;
 use Opifer\ContentBundle\Form\Type\BoxModelType;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -48,13 +49,8 @@ class SectionBlockService extends AbstractBlockService implements BlockServiceIn
         $builder->get('properties')
             ->add('id', TextType::class, ['attr' => ['help_text' => 'help.html_id'],'required' => false])
             ->add('extra_classes', TextType::class, ['attr' => ['help_text' => 'help.extra_classes'],'required' => false])
-            ->add('styles', ChoiceType::class, [
-                'label' => 'label.styling',
+            ->add('styles', StylesType::class, [
                 'choices'  => $this->config['styles'],
-                'required' => false,
-                'expanded' => true,
-                'multiple' => true,
-                'attr' => ['help_text' => 'help.html_styles', 'tag' => 'styles'],
             ])
             ->add('padding', BoxModelType::class, [
                 'type' => 'padding',

--- a/src/ContentBundle/Block/Service/TabNavBlockService.php
+++ b/src/ContentBundle/Block/Service/TabNavBlockService.php
@@ -8,6 +8,7 @@ use Opifer\ContentBundle\Block\Tool\ToolsetMemberInterface;
 use Opifer\ContentBundle\Entity\Block;
 use Opifer\ContentBundle\Entity\TabNavBlock;
 use Opifer\ContentBundle\Entity\TabsBlock;
+use Opifer\ContentBundle\Form\Type\StylesType;
 use Opifer\ContentBundle\Form\Type\TabType;
 use Opifer\ContentBundle\Model\BlockInterface;
 
@@ -82,13 +83,8 @@ class TabNavBlockService extends AbstractBlockService implements LayoutBlockServ
 
         if ($this->config['styles']) {
             $builder->get('properties')
-                ->add('styles', ChoiceType::class, [
-                    'label' => 'label.styling',
+                ->add('styles', StylesType::class, [
                     'choices'  => $this->config['styles'],
-                    'required' => false,
-                    'expanded' => true,
-                    'multiple' => true,
-                    'attr' => ['help_text' => 'help.html_styles','tag' => 'styles'],
                 ]);
         }
     }

--- a/src/ContentBundle/Form/Type/StylesType.php
+++ b/src/ContentBundle/Form/Type/StylesType.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Opifer\ContentBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class StylesType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addModelTransformer(new CallbackTransformer(
+            function ($array) {
+                return $array;
+            },
+            function ($array) {
+                // Always convert the values to a simple array, since in some cases the values might be passed with custom
+                // keys, which is then converted to an object on json_encoding.
+                return array_values($array);
+            }
+        ));
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'label' => 'label.styling',
+            'required' => false,
+            'expanded' => true,
+            'multiple' => true,
+            'attr' => ['help_text' => 'help.html_styles', 'tag' => 'styles'],
+        ]);
+    }
+
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+}


### PR DESCRIPTION
This solves the issue where style options are sometimes stored as an object instead of an array.